### PR TITLE
Pug Example

### DIFF
--- a/Pubchem PUG example.ipynb
+++ b/Pubchem PUG example.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example how to use Pubchem PUG to bulk download list of CID and their smiles. The PUG POST request returns XML with an FTP link for the requested list in the requested format\n",
+    "\n",
+    "This should also be useful to download CSV data for AID's, theres an example at https://pubchemdocs.ncbi.nlm.nih.gov/power-user-gateway$_3-2-2 how to download two assays in CSV format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\"?>\n",
+      "<!DOCTYPE PCT-Data PUBLIC \"-//NCBI//NCBI PCTools/EN\" \"http://pubchem.ncbi.nlm.nih.gov/pug/pug.dtd\">\n",
+      "<PCT-Data>\n",
+      "  <PCT-Data_output>\n",
+      "    <PCT-OutputData>\n",
+      "      <PCT-OutputData_status>\n",
+      "        <PCT-Status-Message>\n",
+      "          <PCT-Status-Message_status>\n",
+      "            <PCT-Status value=\"success\"/>\n",
+      "          </PCT-Status-Message_status>\n",
+      "        </PCT-Status-Message>\n",
+      "      </PCT-OutputData_status>\n",
+      "      <PCT-OutputData_output>\n",
+      "        <PCT-OutputData_output_download-url>\n",
+      "          <PCT-Download-URL>\n",
+      "            <PCT-Download-URL_url>ftp://ftp-private.ncbi.nlm.nih.gov/pubchem/.fetch/2/1369773995629144774.txt</PCT-Download-URL_url>\n",
+      "          </PCT-Download-URL>\n",
+      "        </PCT-OutputData_output_download-url>\n",
+      "      </PCT-OutputData_output>\n",
+      "    </PCT-OutputData>\n",
+      "  </PCT-Data_output>\n",
+      "</PCT-Data>\n",
+      "\n",
+      "200\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Example from here https://stackoverflow.com/questions/4476373/simple-url-get-post-function-in-python\n",
+    "import requests\n",
+    "url = 'https://pubchem.ncbi.nlm.nih.gov/pug/pug.cgi'\n",
+    "#payload = {'key1': 'value1', 'key2': 'value2'}\n",
+    "\n",
+    "#Payload example generated with https://pubchem.ncbi.nlm.nih.gov/pc_fetch/pc_fetch.cgi\n",
+    "payload = \"\"\"<?xml version=\"1.0\"?>\n",
+    "<!DOCTYPE PCT-Data PUBLIC \"-//NCBI//NCBI PCTools/EN\" \"http://pubchem.ncbi.nlm.nih.gov/pug/pug.dtd\">\n",
+    "<PCT-Data>\n",
+    "  <PCT-Data_input>\n",
+    "    <PCT-InputData>\n",
+    "      <PCT-InputData_download>\n",
+    "        <PCT-Download>\n",
+    "          <PCT-Download_uids>\n",
+    "            <PCT-QueryUids>\n",
+    "              <PCT-QueryUids_ids>\n",
+    "                <PCT-ID-List>\n",
+    "                  <PCT-ID-List_db>pccompound</PCT-ID-List_db>\n",
+    "                  <PCT-ID-List_uids>\n",
+    "                    <PCT-ID-List_uids_E>241</PCT-ID-List_uids_E>\n",
+    "                    <PCT-ID-List_uids_E>727</PCT-ID-List_uids_E>\n",
+    "                  </PCT-ID-List_uids>\n",
+    "                </PCT-ID-List>\n",
+    "              </PCT-QueryUids_ids>\n",
+    "            </PCT-QueryUids>\n",
+    "          </PCT-Download_uids>\n",
+    "          <PCT-Download_format value=\"smiles\"/>\n",
+    "          <PCT-Download_compression value=\"none\"/>\n",
+    "          <PCT-Download_use-3d value=\"false\"/>\n",
+    "        </PCT-Download>\n",
+    "      </PCT-InputData_download>\n",
+    "    </PCT-InputData>\n",
+    "  </PCT-Data_input>\n",
+    "</PCT-Data>\"\"\"\n",
+    "# GET\n",
+    "#r = requests.get(url)\n",
+    "\n",
+    "# GET with params in URL\n",
+    "#r = requests.get(url, params=payload)\n",
+    "\n",
+    "# POST with form-encoded data\n",
+    "r = requests.post(url, data=payload)\n",
+    "\n",
+    "# POST with JSON \n",
+    "#import json\n",
+    "#r = requests.post(url, data=json.dumps(payload))\n",
+    "\n",
+    "# Response, status etc\n",
+    "print(r.text)\n",
+    "print(r.status_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi Gabriel,
  I think it could be best in the long run, if we try to avoid manual download. The Pubchem Pug interface should be useful here. Crafting an XML post, can give us a ftp link to a file with either compound info or Bioassay info in a requested format. There's some links in the ipynb notebook.

Best Regards
Esben